### PR TITLE
Implements network-wide usage limits

### DIFF
--- a/includes/Application/Shortcode/ResultsShortcode.php
+++ b/includes/Application/Shortcode/ResultsShortcode.php
@@ -4,6 +4,8 @@ namespace RRZE\RRZESearch\Application\Shortcode;
 defined( 'ABSPATH' ) || exit;
 
 use RRZE\RRZESearch\Domain\Contract\Engine;
+use RRZE\RRZESearch\Infrastructure\UsageLimiter;
+use RRZE\RRZESearch\Infrastructure\Engines\Foundations\WordPressSearch;
 
 /**
  * Renders the RRZE Search results via the `[rrze_search_results]` shortcode.
@@ -94,6 +96,13 @@ class ResultsShortcode
             $useengine  = absint($_GET['se']);
         }
 
+        if (UsageLimiter::shouldForceFallback()) {
+            $fallbackEngineKey = $this->findWordPressEngineKey($engines);
+            if ($fallbackEngineKey !== null) {
+                $useengine = $fallbackEngineKey;
+            }
+        }
+
         if ((isset($useengine)) && (isset($resources[$useengine]))) {
             $resource     = $resources[$useengine];
         }
@@ -114,13 +123,22 @@ class ResultsShortcode
             $this->searchEngine = new $resource['resource_class'];
             $searchEngineClass  = substr(strrchr(get_parent_class($this->searchEngine), '\\'), 1);
 
-            $queryResults = $this->searchEngine->query($query, $resource['args'], $startPage);
+            $queryResults = $this->searchEngine->query($query, $resource['args'] ?? [], $startPage);
             $results      = is_array($queryResults) ? $queryResults : json_decode($queryResults, true);
+
+            $fallbackPayload = null;
+            if (isset($results['fallback_engine']) && $results['fallback_engine'] === WordPressSearch::class) {
+                $fallbackPayload = $results;
+                $results = isset($results['results']) && is_array($results['results']) ? $results['results'] : [];
+            }
 
             $currentEngineKey    = $useengine;
             $currentEngineConfig = $resource;
 
-            if ((isset($results['error'])) && ($results['error']['code']>=400)) {
+            if ($fallbackPayload !== null) {
+                $searchEngineClass = 'WordPressSearch';
+                include \dirname(__DIR__, 2).$templatesDir.'Results'.DIRECTORY_SEPARATOR.'WordPressSearch-shortcode.php';
+            } elseif ((isset($results['error'])) && ($results['error']['code']>=400)) {
                 include \dirname(__DIR__, 2).$templatesDir.'Results'.DIRECTORY_SEPARATOR.'Error-shortcode.php';
             }  else {
                 include \dirname(__DIR__, 2).$templatesDir.'Results'.DIRECTORY_SEPARATOR.$searchEngineClass.'-shortcode.php';
@@ -130,5 +148,28 @@ class ResultsShortcode
         } else {
             include \dirname(__DIR__, 2).$templatesDir.'Results'.DIRECTORY_SEPARATOR.'Error-shortcode.php';
         }
+    }
+
+    /**
+     * Locate the native WordPress engine index if available.
+     *
+     * @param array<int, array<string,mixed>> $engines
+     */
+    private function findWordPressEngineKey(array $engines): ?int
+    {
+        foreach ($engines as $index => $engine) {
+            if (!is_array($engine)) {
+                continue;
+            }
+            $class = isset($engine['resource_class']) ? (string)$engine['resource_class'] : '';
+            if ($class === '') {
+                continue;
+            }
+            if (stripos($class, 'WordPress') !== false) {
+                return (int)$index;
+            }
+        }
+
+        return null;
     }
 }

--- a/includes/Application/Widget/SearchWidget.php
+++ b/includes/Application/Widget/SearchWidget.php
@@ -5,6 +5,7 @@ defined( 'ABSPATH' ) || exit;
 
 use RRZE\RRZESearch\Domain\Contract\Engine;
 use RRZE\RRZESearch\Infrastructure\Helper\Helper;
+use RRZE\RRZESearch\Infrastructure\UsageLimiter;
 use WP_Widget;
 
 /**
@@ -210,7 +211,14 @@ class SearchWidget extends WP_Widget
     {
         echo $args['before_widget'];
 
+        [$limitAvailable] = UsageLimiter::canConsumeRequest();
+
         $preferredEngine = empty($_COOKIE['rrze_search_engine_pref']) ? (int)$instance['search_engine'] : (int)$_COOKIE['rrze_search_engine_pref'];
+        $forceLocalSearch = !$limitAvailable || UsageLimiter::shouldForceFallback();
+        $localEngineKey = $this->getWordPressEngineKey();
+        if ($forceLocalSearch && $localEngineKey !== null) {
+            $preferredEngine = (int) $localEngineKey;
+        }
         $resources = [];
 
         foreach ($this->options['rrze_search_engines'] as $key => $engine) {
@@ -224,6 +232,9 @@ class SearchWidget extends WP_Widget
                 $resources[$key]['args'] = $resource['args'];
             }
         }
+        $engineSelectionDisabled = $forceLocalSearch;
+        $fallbackEngineKey = (int) $preferredEngine;
+
         include \dirname(__DIR__,
                 2) . DIRECTORY_SEPARATOR . 'Infrastructure' . DIRECTORY_SEPARATOR . 'Templates' . DIRECTORY_SEPARATOR . 'widget.php';
 
@@ -237,7 +248,13 @@ class SearchWidget extends WP_Widget
      */
     public function widgetSubmit(): void
     {
+        [$limitAvailable] = UsageLimiter::canConsumeRequest();
+        $forceLocalSearch = !$limitAvailable || UsageLimiter::shouldForceFallback();
         $resourceId = isset($_POST['resource_id']) ? absint($_POST['resource_id']) : null;
+        $localEngineKey = $this->getWordPressEngineKey();
+        if ($forceLocalSearch && $localEngineKey !== null) {
+            $resourceId = (int) $localEngineKey;
+        }
 
         $engines = $this->options['rrze_search_engines'] ?? [];
         $engineEntry = null;
@@ -281,5 +298,30 @@ class SearchWidget extends WP_Widget
 
         wp_redirect($redirect_link);
         exit;
+    }
+
+    /**
+     * Locate the engine index that represents the local WordPress search.
+     */
+    protected function getWordPressEngineKey(): ?int
+    {
+        if (empty($this->options['rrze_search_engines']) || !is_array($this->options['rrze_search_engines'])) {
+            return null;
+        }
+
+        foreach ($this->options['rrze_search_engines'] as $key => $engine) {
+            if (!is_array($engine)) {
+                continue;
+            }
+            $class = isset($engine['resource_class']) ? (string)$engine['resource_class'] : '';
+            if ($class === '') {
+                continue;
+            }
+            if (stripos($class, 'WordPress') !== false) {
+                return (int)$key;
+            }
+        }
+
+        return null;
     }
 }

--- a/includes/Infrastructure/Engines/Foundations/GoogleSearch.php
+++ b/includes/Infrastructure/Engines/Foundations/GoogleSearch.php
@@ -32,6 +32,8 @@
 namespace RRZE\RRZESearch\Infrastructure\Engines\Foundations;
 defined( 'ABSPATH' ) || exit;
 
+use RRZE\RRZESearch\Infrastructure\UsageLimiter;
+
 /**
  * Google Custom Search Engine
  *
@@ -70,6 +72,28 @@ class GoogleSearch extends AbstractSearchEngine
             ];
         }
 
+        [$canConsume, $exceeded] = UsageLimiter::canConsumeRequest();
+        if (!$canConsume) {
+            $message = __('RRZE Search usage limit reached.', 'rrze-search');
+            $suffix  = UsageLimiter::describeExceededPeriods($exceeded);
+            if ($suffix !== '') {
+                $message = sprintf(
+                    __('RRZE Search usage limit reached (%s).', 'rrze-search'),
+                    $suffix
+                );
+            }
+
+            return [
+                'error' => [
+                    'code'    => 429,
+                    'message' => $message,
+                    'details' => [
+                        'blocked_periods' => $exceeded,
+                    ],
+                ],
+            ];
+        }
+
         $requestQueryArgs = [
             'cx'    => $args['cx'],
             'key'   => $args['key'],
@@ -89,6 +113,11 @@ class GoogleSearch extends AbstractSearchEngine
             'headers'   => [
                 'Accept' => 'application/json',
             ],
+        ]);
+
+        UsageLimiter::recordIncrement([
+            'engine'  => static::class,
+            'site_id' => function_exists('get_current_blog_id') ? get_current_blog_id() : null,
         ]);
 
         if (is_wp_error($response)) {

--- a/includes/Infrastructure/Engines/Foundations/GoogleSearch.php
+++ b/includes/Infrastructure/Engines/Foundations/GoogleSearch.php
@@ -33,6 +33,7 @@ namespace RRZE\RRZESearch\Infrastructure\Engines\Foundations;
 defined( 'ABSPATH' ) || exit;
 
 use RRZE\RRZESearch\Infrastructure\UsageLimiter;
+use RRZE\RRZESearch\Infrastructure\Engines\Foundations\WordPressSearch;
 
 /**
  * Google Custom Search Engine
@@ -74,23 +75,14 @@ class GoogleSearch extends AbstractSearchEngine
 
         [$canConsume, $exceeded] = UsageLimiter::canConsumeRequest();
         if (!$canConsume) {
-            $message = __('RRZE Search usage limit reached.', 'rrze-search');
-            $suffix  = UsageLimiter::describeExceededPeriods($exceeded);
-            if ($suffix !== '') {
-                $message = sprintf(
-                    __('RRZE Search usage limit reached (%s).', 'rrze-search'),
-                    $suffix
-                );
-            }
+            $fallbackEngine = new WordPressSearch();
+            $fallback = $fallbackEngine->query($query, $args, $startPage);
+            $decoded = is_array($fallback) ? $fallback : json_decode((string) $fallback, true);
 
             return [
-                'error' => [
-                    'code'    => 429,
-                    'message' => $message,
-                    'details' => [
-                        'blocked_periods' => $exceeded,
-                    ],
-                ],
+                'fallback_engine' => WordPressSearch::class,
+                'results'         => is_array($decoded) ? $decoded : [],
+                'blocked_periods' => $exceeded,
             ];
         }
 

--- a/includes/Infrastructure/ServiceProvider.php
+++ b/includes/Infrastructure/ServiceProvider.php
@@ -5,6 +5,7 @@ defined( 'ABSPATH' ) || exit;
 
 use RRZE\RRZESearch\Application\Controller\ShortcodeController;
 use RRZE\RRZESearch\Application\Controller\WidgetController;
+use RRZE\RRZESearch\Infrastructure\UsageLimiter;
 use UTN\BiteEmbed\Block;
 
 /**

--- a/includes/Infrastructure/ServiceProvider.php
+++ b/includes/Infrastructure/ServiceProvider.php
@@ -29,6 +29,7 @@ class ServiceProvider
             SettingsPage::class,
             ScriptEnqueuer::class,
             SettingsLink::class,
+            UsageLimiter::class,
             WidgetController::class,
             ShortcodeController::class,
             BlockRegistration::class,

--- a/includes/Infrastructure/Templates/widget.php
+++ b/includes/Infrastructure/Templates/widget.php
@@ -36,41 +36,45 @@ $staticLinks;
                         </div>
                         <div class="search-settings" role="radiogroup"
                              aria-label="<?php echo __('Available search engines', 'rrze-search'); ?>">
-                            <p id="search-engines"
-                               class="screen-reader-text"><?php echo __('Please select one of the available search engines:', 'rrze-search'); ?></p>
-                            <?php
-                            $idx = 0;
-                            foreach ($resources as $key => $resource):
-                                if (!empty($resource['enabled'])) {
-                                    $idx++;
-                                    $id = 'resource-' . esc_attr($key) . '-' . $idx; // eindeutige id
-                                    $isPreferred = ($preferredEngine == $key);
-                                    $tabIndex = $isPreferred ? '0' : '-1'; // 0 statt 1 für Fokussierbarkeit
-                                    $searchEngineDisclaimer = '';
+                            <?php if (!empty($engineSelectionDisabled)) : ?>
+                                <input type="hidden" name="resource_id" value="<?= esc_attr($fallbackEngineKey); ?>">
+                            <?php else : ?>
+                                <p id="search-engines"
+                                   class="screen-reader-text"><?php echo __('Please select one of the available search engines:', 'rrze-search'); ?></p>
+                                <?php
+                                $idx = 0;
+                                foreach ($resources as $key => $resource):
+                                    if (!empty($resource['enabled'])) {
+                                        $idx++;
+                                        $id = 'resource-' . esc_attr($key) . '-' . $idx; // eindeutige id
+                                        $isPreferred = ($preferredEngine == $key);
+                                        $tabIndex = $isPreferred ? '0' : '-1'; // 0 statt 1 für Fokussierbarkeit
+                                        $searchEngineDisclaimer = '';
 
-                                    if (!empty($resource['resource_disclaimer'])) {
-                                        $searchEngineDisclaimer = ' (<a href="' . get_permalink($resource['resource_disclaimer']) . '"' .
-                                            (!empty($privacylabeltarget) ? ' target="' . $privacylabeltarget . '"' : '') .
-                                            '>' . __('Privacy Disclaimer', 'rrze-search') . '</a>)';
+                                        if (!empty($resource['resource_disclaimer'])) {
+                                            $searchEngineDisclaimer = ' (<a href="' . get_permalink($resource['resource_disclaimer']) . '"' .
+                                                (!empty($privacylabeltarget) ? ' target="' . $privacylabeltarget . '"' : '') .
+                                                '>' . __('Privacy Disclaimer', 'rrze-search') . '</a>)';
+                                        }
+                                        ?>
+                                        <input
+                                                type="radio"
+                                                id="<?= $id; ?>"
+                                                name="resource_id"
+                                                class="search-engine"
+                                                value="<?= esc_attr($key); ?>"
+                                            <?= checked($preferredEngine, $key, false); ?>
+                                                aria-checked="<?= $isPreferred ? 'true' : 'false'; ?>"
+                                                tabindex="<?= $tabIndex; ?>"
+                                        >
+                                        <label for="<?= $id; ?>">
+                                            <?= esc_html($resource['resource_name']); ?><?= $searchEngineDisclaimer; ?>
+                                        </label>
+                                        <?php
                                     }
-                                    ?>
-                                    <input
-                                            type="radio"
-                                            id="<?= $id; ?>"
-                                            name="resource_id"
-                                            class="search-engine"
-                                            value="<?= esc_attr($key); ?>"
-                                        <?= checked($preferredEngine, $key, false); ?>
-                                            aria-checked="<?= $isPreferred ? 'true' : 'false'; ?>"
-                                            tabindex="<?= $tabIndex; ?>"
-                                    >
-                                    <label for="<?= $id; ?>">
-                                        <?= esc_html($resource['resource_name']); ?><?= $searchEngineDisclaimer; ?>
-                                    </label>
-                                    <?php
-                                }
-                            endforeach;
-                            ?>
+                                endforeach;
+                                ?>
+                            <?php endif; ?>
                         </div>
                     </form>
                 </div>

--- a/includes/Infrastructure/UsageLimiter.php
+++ b/includes/Infrastructure/UsageLimiter.php
@@ -17,12 +17,16 @@ final class UsageLimiter
 
     private const PERIODS = ['hour', 'day', 'week', 'month', 'year'];
 
+    private const TRANSIENT_KEY = 'rrze_search_limit_block';
+
     /**
      * Wire the limit enforcement into rrze_search_increment handling.
      */
     public function register(): void
     {
         add_filter('rrze_search_should_increment', [$this, 'enforceIncrementLimits'], 10, 2);
+        add_action('admin_notices', [$this, 'renderAdminNotice']);
+        add_action('network_admin_notices', [$this, 'renderAdminNotice']);
     }
 
     /**
@@ -41,6 +45,7 @@ final class UsageLimiter
         $option = get_site_option(self::OPTION_NAME, null);
 
         if (!is_array($option)) {
+            self::clearBlockedState();
             return [true, []];
         }
 
@@ -64,7 +69,13 @@ final class UsageLimiter
             }
         }
 
-        return [empty($exceeded), $exceeded];
+        if (!empty($exceeded)) {
+            self::storeBlockedState($exceeded);
+            return [false, $exceeded];
+        }
+
+        self::clearBlockedState();
+        return [true, []];
     }
 
     /**
@@ -108,6 +119,27 @@ final class UsageLimiter
     }
 
     /**
+     * Whether engine selection widgets should be hidden due to a temporary block.
+     */
+    public static function shouldForceFallback(): bool
+    {
+        return !empty(self::getBlockedState());
+    }
+
+    /**
+     * Returns metadata about the current block, if any.
+     *
+     * @return array<string,mixed>
+     */
+    public static function getBlockedMetadata(): array
+    {
+        $state = self::getBlockedState();
+        return isset($state['exceeded']) && is_array($state['exceeded'])
+            ? $state['exceeded']
+            : [];
+    }
+
+    /**
      * Filter callback that blocks increments when limits are reached.
      *
      * @param bool  $allowed Current allowance passed through the filter chain.
@@ -121,6 +153,36 @@ final class UsageLimiter
 
         [$canConsume] = self::canConsumeRequest();
         return $canConsume;
+    }
+
+    /**
+     * Display an admin notice when RRZE Search limits prevent remote queries.
+     */
+    public function renderAdminNotice(): void
+    {
+        if ((function_exists('wp_doing_ajax') && wp_doing_ajax()) || !is_user_logged_in()) {
+            return;
+        }
+
+        if (!current_user_can('manage_options')) {
+            return;
+        }
+
+        [$allowed, $exceeded] = self::canConsumeRequest();
+        if ($allowed || empty($exceeded)) {
+            return;
+        }
+
+        $summary = self::describeExceededPeriods($exceeded);
+        $message = __('RRZE Search usage limit reached. Remote search will fall back to the local search until quotas reset.', 'rrze-search');
+        if ($summary !== '') {
+            $message = sprintf(
+                __('RRZE Search usage limit reached (%s). Remote search will fall back to the local search until quotas reset.', 'rrze-search'),
+                $summary
+            );
+        }
+
+        printf('<div class="notice notice-warning"><p>%s</p></div>', esc_html($message));
     }
 
     /**
@@ -143,5 +205,50 @@ final class UsageLimiter
 
         return $normalized;
     }
-}
 
+    /**
+     * Persist a short-lived block state when limits are hit.
+     *
+     * @param array<string,array<string,int>> $exceeded
+     */
+    private static function storeBlockedState(array $exceeded): void
+    {
+        $payload = [
+            'blocked'  => true,
+            'exceeded' => $exceeded,
+            'stored'   => time(),
+        ];
+
+        $ttl = HOUR_IN_SECONDS;
+
+        if (is_multisite()) {
+            set_site_transient(self::TRANSIENT_KEY, $payload, $ttl);
+        } else {
+            set_transient(self::TRANSIENT_KEY, $payload, $ttl);
+        }
+    }
+
+    /**
+     * Remove any cached block state when limits allow consumption again.
+     */
+    private static function clearBlockedState(): void
+    {
+        if (is_multisite()) {
+            delete_site_transient(self::TRANSIENT_KEY);
+        } else {
+            delete_transient(self::TRANSIENT_KEY);
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private static function getBlockedState(): array
+    {
+        $value = is_multisite()
+            ? get_site_transient(self::TRANSIENT_KEY)
+            : get_transient(self::TRANSIENT_KEY);
+
+        return is_array($value) ? $value : [];
+    }
+}

--- a/includes/Infrastructure/UsageLimiter.php
+++ b/includes/Infrastructure/UsageLimiter.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace RRZE\RRZESearch\Infrastructure;
+
+defined('ABSPATH') || exit;
+
+/**
+ * Enforces the network-wide RRZE Search usage limits when present.
+ *
+ * Provides helpers to check whether a request may be performed, to describe
+ * exceeded periods, and to dispatch the increment hook that the network
+ * settings plugin listens to.
+ */
+final class UsageLimiter
+{
+    private const OPTION_NAME = 'rrze_search_network_limits_and_stats';
+
+    private const PERIODS = ['hour', 'day', 'week', 'month', 'year'];
+
+    /**
+     * Wire the limit enforcement into rrze_search_increment handling.
+     */
+    public function register(): void
+    {
+        add_filter('rrze_search_should_increment', [$this, 'enforceIncrementLimits'], 10, 2);
+    }
+
+    /**
+     * Determines whether another RRZE Search request may be consumed.
+     *
+     * @return array{0: bool, 1: array<string, array<string,int>>} Tuple of
+     *         [isAllowed, exceededPeriods]. The second element contains any
+     *         periods that are already at or above their limit.
+     */
+    public static function canConsumeRequest(): array
+    {
+        if (!is_multisite()) {
+            return [true, []];
+        }
+
+        $option = get_site_option(self::OPTION_NAME, null);
+
+        if (!is_array($option)) {
+            return [true, []];
+        }
+
+        $limits = self::normalizePeriods($option['limits'] ?? []);
+        $totals = self::normalizePeriods($option['totals'] ?? []);
+
+        $exceeded = [];
+
+        foreach (self::PERIODS as $period) {
+            $limit = $limits[$period] ?? 0;
+            if ($limit <= 0) {
+                continue;
+            }
+
+            $total = $totals[$period] ?? 0;
+            if ($total >= $limit) {
+                $exceeded[$period] = [
+                    'limit' => $limit,
+                    'total' => $total,
+                ];
+            }
+        }
+
+        return [empty($exceeded), $exceeded];
+    }
+
+    /**
+     * Formats the exceeded periods for display in error messages.
+     *
+     * @param array<string, array<string,int>> $exceeded
+     */
+    public static function describeExceededPeriods(array $exceeded): string
+    {
+        if ($exceeded === []) {
+            return '';
+        }
+
+        $labels = [
+            'hour'  => __('hourly', 'rrze-search'),
+            'day'   => __('daily', 'rrze-search'),
+            'week'  => __('weekly', 'rrze-search'),
+            'month' => __('monthly', 'rrze-search'),
+            'year'  => __('yearly', 'rrze-search'),
+        ];
+
+        $parts = [];
+        foreach ($exceeded as $period => $stats) {
+            $label = $labels[$period] ?? $period;
+            $limit = (int) ($stats['limit'] ?? 0);
+            $total = (int) ($stats['total'] ?? 0);
+            $parts[] = sprintf('%s %d/%d', $label, $total, $limit);
+        }
+
+        return implode(', ', $parts);
+    }
+
+    /**
+     * Dispatches the increment hook so the network plugin can count usage.
+     *
+     * @param array<string,mixed> $context Optional metadata about the request.
+     */
+    public static function recordIncrement(array $context = []): void
+    {
+        do_action('rrze_search_increment', $context);
+    }
+
+    /**
+     * Filter callback that blocks increments when limits are reached.
+     *
+     * @param bool  $allowed Current allowance passed through the filter chain.
+     * @param array $context Metadata supplied by the increment caller.
+     */
+    public function enforceIncrementLimits(bool $allowed, array $context): bool
+    {
+        if (!$allowed) {
+            return false;
+        }
+
+        [$canConsume] = self::canConsumeRequest();
+        return $canConsume;
+    }
+
+    /**
+     * @param mixed $values
+     *
+     * @return array<string,int>
+     */
+    private static function normalizePeriods($values): array
+    {
+        if (!is_array($values)) {
+            return [];
+        }
+
+        $normalized = [];
+        foreach (self::PERIODS as $period) {
+            if (isset($values[$period])) {
+                $normalized[$period] = max(0, (int) $values[$period]);
+            }
+        }
+
+        return $normalized;
+    }
+}
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rrze-search",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "rrze-search.php",
   "textdomain": "rrze-search",

--- a/rrze-search.php
+++ b/rrze-search.php
@@ -5,7 +5,7 @@ Plugin URI: https://www.tollwerk.de
 description: A WordPress Search Plugin originally by Tollwerk GmbH and maintained by RRZE
 Author: Tollwerk & RRZE
 Author URI: https://www.tollwerk.de
-Version: 1.0.0
+Version: 1.0.1
 License: GPL3
 Text Domain: rrze-search
 Domain Path: /languages


### PR DESCRIPTION
Implements network-wide usage limits for RRZE Search to control the number of requests. It introduces a usage limiter that checks limits, handles fallback to local search when limits are reached, and dispatches increment hooks for network-wide usage tracking.

- Adds `UsageLimiter` class to enforce network-wide RRZE Search usage limits.
- Modifies `ResultsShortcode` to force fallback to WordPress search engine when limits are reached.
- Updates `SearchWidget` to disable engine selection and force local search when limits are reached.
- Updates GoogleSearch to fallback to local search